### PR TITLE
Change cron UTC time to 00, 6a, Noon, 6p EST

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ workflows:
   main-workflow:
     triggers:
       - schedule:
-          cron: '0 11,23 * * *'
+          cron: '0 05,11,17,23 * * *'
           filters:
             branches:
               only:


### PR DESCRIPTION
The time used in the YAML by circle CI is UTC, hence it appears not to match the desired, 00, 6a, Noon, 6p, schedule but they are adjusted for the UTC offset. 